### PR TITLE
removed attributes from Manifest

### DIFF
--- a/MarkdownView/markdownview/src/main/AndroidManifest.xml
+++ b/MarkdownView/markdownview/src/main/AndroidManifest.xml
@@ -1,11 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="us.feras.mdv">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
+    <application>
     </application>
 
 </manifest>


### PR DESCRIPTION
these attributes should belong to the application project, not to the library project
They cause problems in applications project using that library, e.g.:

Attribute application@label value=(@string/appName) from [:features:base] AndroidManifest.xml:51:9-40
	is also present at [us.feras.mdv:markdownview:1.1.0] AndroidManifest.xml:13:9-41 value=(@string/app_name).
	Suggestion: add 'tools:replace="android:label"' to <application> element at AndroidManifest.xml:6:5-157:19 to override.

It might be easily fixable with the tools:replace Attribute, but thats more a workaround than a real fix...